### PR TITLE
RSLiDAR SDK restructure for external projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,8 +164,8 @@ include_directories(${rs_driver_INCLUDE_DIRS})
 #========================
 
 add_executable(rslidar_sdk_node
-            #    node/trossen_rslidar_node.cpp
-                node/rslidar_sdk_node.cpp
+               node/trossen_rslidar_node.cpp
+                # node/rslidar_sdk_node.cpp
                 src/manager/node_manager.cpp)
 
 target_link_libraries(rslidar_sdk_node                   

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ include_directories(${rs_driver_INCLUDE_DIRS})
 
 add_executable(rslidar_sdk_node
                node/trossen_rslidar_node.cpp
-                src/manager/node_manager.cpp)
+               src/manager/node_manager.cpp)
 
 target_link_libraries(rslidar_sdk_node
                       ${YAML_CPP_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,61 +74,14 @@ elseif(${POINT_TYPE} STREQUAL "XYZIRT")
   add_definitions(-DPOINT_TYPE_XYZIRT)
 endif()
 
-message(=============================================================)
-message("-- POINT_TYPE is ${POINT_TYPE}")
-message(=============================================================)
-
 #========================
 # Dependencies Setup
 #========================
-
-#ROS#
-find_package(roscpp 1.12 QUIET)
-
-if(roscpp_FOUND)
-
-  message(=============================================================)
-  message("-- ROS Found. ROS Support is turned On.")
-  message(=============================================================)
-
-  add_definitions(-DROS_FOUND)
-
-  find_package(roslib QUIET)
-  include_directories(${roscpp_INCLUDE_DIRS} ${roslib_INCLUDE_DIRS})
-  set(ROS_LIBS ${roscpp_LIBRARIES} ${roslib_LIBRARIES})
-
-  #Catkin#
-  if(${COMPILE_METHOD} STREQUAL "CATKIN")
-
-    add_definitions(-DRUN_IN_ROS_WORKSPACE)
-
-    find_package(catkin REQUIRED COMPONENTS
-      roscpp
-      sensor_msgs
-      roslib)
-
-    catkin_package(CATKIN_DEPENDS 
-      sensor_msgs 
-      roslib)
-
-  endif(${COMPILE_METHOD} STREQUAL "CATKIN")
-
-else(roscpp_FOUND)
-
-  message(=============================================================)
-  message("-- ROS Not Found. ROS Support is turned Off.")
-  message(=============================================================)
-
-endif(roscpp_FOUND)
 
 #ROS2#
 find_package(rclcpp QUIET)
 
 if(rclcpp_FOUND AND ${COMPILE_METHOD} STREQUAL "COLCON")
-
-  message(=============================================================)
-  message("-- ROS2 Found. ROS2 Support is turned On.")
-  message(=============================================================)
 
   add_definitions(-DROS2_FOUND)
   include_directories(${rclcpp_INCLUDE_DIRS})
@@ -138,13 +91,6 @@ if(rclcpp_FOUND AND ${COMPILE_METHOD} STREQUAL "COLCON")
   find_package(sensor_msgs REQUIRED)
   find_package(rslidar_msg REQUIRED)
   find_package(std_msgs REQUIRED)
-#   find_package(thermal_inspection_ugv_control REQUIRED)
-
-else(rclcpp_FOUND AND ${COMPILE_METHOD} STREQUAL "COLCON")
-
-  message(=============================================================)
-  message("-- ROS2 Not Found. ROS2 Support is turned Off.")
-  message(=============================================================)
 
 endif(rclcpp_FOUND AND ${COMPILE_METHOD} STREQUAL "COLCON")
 
@@ -165,29 +111,11 @@ include_directories(${rs_driver_INCLUDE_DIRS})
 
 add_executable(rslidar_sdk_node
                node/trossen_rslidar_node.cpp
-                # node/rslidar_sdk_node.cpp
                 src/manager/node_manager.cpp)
 
-target_link_libraries(rslidar_sdk_node                   
+target_link_libraries(rslidar_sdk_node
                       ${YAML_CPP_LIBRARIES}
                       ${rs_driver_LIBRARIES})
-
-#Ros#
-if(roscpp_FOUND)
-
-  target_link_libraries(rslidar_sdk_node 
-    ${ROS_LIBS})
-
-  if(${COMPILE_METHOD} STREQUAL "CATKIN")
-
-    install(TARGETS rslidar_sdk_node
-            RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-            LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-            ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
-
-  endif()
-
-endif(roscpp_FOUND)
 
 #Ros2#
 if(rclcpp_FOUND AND ${COMPILE_METHOD} STREQUAL "COLCON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ if(rclcpp_FOUND AND ${COMPILE_METHOD} STREQUAL "COLCON")
   find_package(sensor_msgs REQUIRED)
   find_package(rslidar_msg REQUIRED)
   find_package(std_msgs REQUIRED)
-  find_package(thermal_inspection_ugv_control REQUIRED)
+#   find_package(thermal_inspection_ugv_control REQUIRED)
 
 else(rclcpp_FOUND AND ${COMPILE_METHOD} STREQUAL "COLCON")
 
@@ -164,8 +164,9 @@ include_directories(${rs_driver_INCLUDE_DIRS})
 #========================
 
 add_executable(rslidar_sdk_node
-               node/trossen_rslidar_node.cpp
-               src/manager/node_manager.cpp)
+            #    node/trossen_rslidar_node.cpp
+                node/rslidar_sdk_node.cpp
+                src/manager/node_manager.cpp)
 
 target_link_libraries(rslidar_sdk_node                   
                       ${YAML_CPP_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(POINT_TYPE XYZI)
 #=======================================
 # Compile setup (ORIGINAL, CATKIN, COLCON)
 #=======================================
-set(COMPILE_METHOD CATKIN)
+set(COMPILE_METHOD COLCON)
 
 option(ENABLE_TRANSFORM "Enable transform functions" OFF)
 if(${ENABLE_TRANSFORM})
@@ -137,7 +137,8 @@ if(rclcpp_FOUND AND ${COMPILE_METHOD} STREQUAL "COLCON")
   find_package(ament_cmake REQUIRED)
   find_package(sensor_msgs REQUIRED)
   find_package(rslidar_msg REQUIRED)
-  find_package(std_msgs REQUIRED)                      
+  find_package(std_msgs REQUIRED)
+  find_package(thermal_inspection_ugv_control REQUIRED)
 
 else(rclcpp_FOUND AND ${COMPILE_METHOD} STREQUAL "COLCON")
 
@@ -163,7 +164,7 @@ include_directories(${rs_driver_INCLUDE_DIRS})
 #========================
 
 add_executable(rslidar_sdk_node
-               node/rslidar_sdk_node.cpp
+               node/trossen_rslidar_node.cpp
                src/manager/node_manager.cpp)
 
 target_link_libraries(rslidar_sdk_node                   

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,7 +7,7 @@ common:
   send_point_cloud_ros: true                            #true: Send point cloud through ROS or ROS2
 lidar:
   - driver:
-      lidar_type: RSM1             #LiDAR type - RS16, RS32, RSBP, RSHELIOS, RSHELIOS_16P, RS128, RS80, RS48, RSP128, RSP80, RSP48, 
+      lidar_type: RSHELIOS_16P             #LiDAR type - RS16, RS32, RSBP, RSHELIOS, RSHELIOS_16P, RS128, RS80, RS48, RSP128, RSP80, RSP48, 
                                    #             RSM1, RSM1_JUMBO, RSM2, RSE1
       msop_port: 6699              #Msop port of lidar
       difop_port: 7788             #Difop port of lidar
@@ -20,8 +20,8 @@ lidar:
                                    #False-- Use the system clock as the timestamp
       pcap_path: /home/robosense/lidar.pcap #The path of pcap file
     ros:
-      ros_frame_id: rslidar                           #Frame id of packet message and point cloud message
-      ros_recv_packet_topic: /rslidar_packets          #Topic used to receive lidar packets from ROS
-      ros_send_packet_topic: /rslidar_packets          #Topic used to send lidar packets through ROS
-      ros_send_point_cloud_topic: /rslidar_points      #Topic used to send point cloud through ROS
+      ros_frame_id: lidar_front                           #Frame id of packet message and point cloud message
+      ros_recv_packet_topic: packets          #Topic used to receive lidar packets from ROS
+      ros_send_packet_topic: packets          #Topic used to send lidar packets through ROS
+      ros_send_point_cloud_topic: points      #Topic used to send point cloud through ROS
 

--- a/node/trossen_rslidar_node.cpp
+++ b/node/trossen_rslidar_node.cpp
@@ -1,0 +1,127 @@
+/*********************************************************************************************************************
+Copyright (c) 2020 RoboSense
+All rights reserved
+
+By downloading, copying, installing or using the software you agree to this license. If you do not agree to this
+license, do not download, install, copy or use the software.
+
+License Agreement
+For RoboSense LiDAR SDK Library
+(3-clause BSD License)
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the names of the RoboSense, nor Suteng Innovation Technology, nor the names of other contributors may be used
+to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************************************************************/
+
+#include "manager/node_manager.hpp"
+
+#include <rs_driver/macro/version.hpp>
+#include <signal.h>
+
+#ifdef ROS_FOUND
+#include <ros/ros.h>
+#include <ros/package.h>
+#elif ROS2_FOUND
+#include <rclcpp/rclcpp.hpp>
+#endif
+
+using namespace robosense::lidar;
+
+#ifdef ROS2_FOUND
+std::mutex g_mtx;
+std::condition_variable g_cv;
+#endif
+
+static void sigHandler(int sig)
+{
+  RS_MSG << "RoboSense-LiDAR-Driver is stopping....." << RS_REND;
+
+#ifdef ROS_FOUND
+  ros::shutdown();
+#elif ROS2_FOUND
+  g_cv.notify_all();
+#endif
+}
+
+int main(int argc, char** argv)
+{
+  signal(SIGINT, sigHandler);  ///< bind ctrl+c signal with the sigHandler function
+
+  RS_TITLE << "********************************************************" << RS_REND;
+  RS_TITLE << "**********                                    **********" << RS_REND;
+  RS_TITLE << "**********    RSLidar_SDK Version: v" << RSLIDAR_VERSION_MAJOR 
+    << "." << RSLIDAR_VERSION_MINOR 
+    << "." << RSLIDAR_VERSION_PATCH << "     **********" << RS_REND;
+  RS_TITLE << "**********                                    **********" << RS_REND;
+  RS_TITLE << "********************************************************" << RS_REND;
+
+#ifdef ROS_FOUND
+  ros::init(argc, argv, "rslidar_sdk_node", ros::init_options::NoSigintHandler);
+#elif ROS2_FOUND
+  rclcpp::init(argc, argv);
+#endif
+
+  std::string config_path;
+
+#ifdef RUN_IN_ROS_WORKSPACE
+   config_path = ros::package::getPath("thermal_inspection_ugv_control");
+#else
+   config_path = (std::string)PROJECT_PATH;
+#endif
+
+   config_path += "/config/rslidar.yaml";
+
+#ifdef ROS_FOUND
+  ros::NodeHandle priv_hh("~");
+  std::string path;
+  priv_hh.param("config_path", path, std::string(""));
+  if (!path.empty())
+  {
+    config_path = path;
+  }
+#endif
+
+  YAML::Node config;
+  try
+  {
+    config = YAML::LoadFile(config_path);
+  }
+  catch (...)
+  {
+    RS_ERROR << "The format of config file " << config_path 
+      << " is wrong. Please check (e.g. indentation)." << RS_REND;
+    return -1;
+  }
+
+  std::shared_ptr<NodeManager> demo_ptr = std::make_shared<NodeManager>();
+  demo_ptr->init(config);
+  demo_ptr->start();
+
+  RS_MSG << "RoboSense-LiDAR-Driver is running....." << RS_REND;
+
+#ifdef ROS_FOUND
+  ros::spin();
+#elif ROS2_FOUND
+  std::unique_lock<std::mutex> lck(g_mtx);
+  g_cv.wait(lck);
+#endif
+
+  return 0;
+}

--- a/node/trossen_rslidar_node.cpp
+++ b/node/trossen_rslidar_node.cpp
@@ -51,7 +51,7 @@ void show_usage(std::string name)
 {
   std::cerr << "Usage: " << name << " <option(s)> SOURCES"
             << "Options:\n"
-            << "\t--config-path\t\tPass the config file absolute path (Required argument)\n"
+            << "\t--config-path\t\tPass the config file absolute path\n"
             << std::endl;
 }
 
@@ -91,7 +91,7 @@ int main(int argc, char ** argv)
   std::string config_path;
   config_path = arg_parser(argc, argv);
   if (config_path == "") {
-    config_path = (std::string)PROJECT_PATH;
+    config_path = static_cast<std::string>(PROJECT_PATH);
     config_path += "/config/config.yaml";
   } else {
     config_path += "/rslidar.yaml";

--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,6 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <depend>rslidar_msg</depend>
-  <!-- <depend>thermal_inspection_ugv_control</depend> -->
   <export>
      <build_type>ament_cmake</build_type>
   </export>

--- a/package.xml
+++ b/package.xml
@@ -3,7 +3,7 @@
   <name>rslidar_sdk</name>
   <version>1.5.0</version>
   <description>The rslidar_sdk package</description>
-  <maintainer email="ron.zheng@robosense.cn">robosense</maintainer>
+  <maintainer email="trsupport@trossenrobotics.com">Trossen Robotics</maintainer>
   <license>BSD</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,7 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <depend>rslidar_msg</depend>
-  <depend>thermal_inspection_ugv_control</depend>
+  <!-- <depend>thermal_inspection_ugv_control</depend> -->
   <export>
      <build_type>ament_cmake</build_type>
   </export>

--- a/package.xml
+++ b/package.xml
@@ -1,17 +1,22 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>rslidar_sdk</name>
   <version>1.5.0</version>
   <description>The rslidar_sdk package</description>
   <maintainer email="ron.zheng@robosense.cn">robosense</maintainer>
   <license>BSD</license>
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>roscpp</build_depend>
+  <build_depend>rclcpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>roslib</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <depend>rslidar_msg</depend>
+  <depend>thermal_inspection_ugv_control</depend>
+  <export>
+     <build_type>ament_cmake</build_type>
+  </export>
 
-  <run_depend>roscpp</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>roslib</run_depend>
 </package>


### PR DESCRIPTION
This pull request modifies the RSLiDAR SDK for external ROS 2-based projects. 
- Accept a config file from an external source
- Build as a ROS 2 package using Colcon
- Cancel the verbose nature of CMakeList during build (a few messages are still displayed by the RSLidar Driver submodule)