### PR TITLE
Add a not-managed version of the RSLidar Node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,8 @@ set(CMAKE_CXX_STANDARD 14)
 
 # Include directory #
 include_directories(
-    ${PROJECT_SOURCE_DIR}/src
-    include
+  ${PROJECT_SOURCE_DIR}/src
+  include
 )
 
 # Driver core #
@@ -93,17 +93,17 @@ find_package(rs_driver REQUIRED)
 include_directories(${rs_driver_INCLUDE_DIRS})
 
 set(DEPENDENCIES
-    nav2_util
-    rclcpp
-    rclcpp_components
-    rslidar_msg
-    sensor_msgs
-    std_msgs
+  nav2_util
+  rclcpp
+  rclcpp_components
+  rslidar_msg
+  sensor_msgs
+  std_msgs
 )
 
 add_library(trossen_rslidar_node SHARED
-    src/trossen_rslidar_node.cpp
-    src/rslidar_helper.cpp
+  src/trossen_rslidar_node.cpp
+  src/rslidar_helper.cpp
 )
 
 add_library(trossen_rslidar_node_managed SHARED
@@ -118,7 +118,7 @@ ament_target_dependencies(trossen_rslidar_node ${DEPENDENCIES})
 ament_target_dependencies(trossen_rslidar_node_managed ${DEPENDENCIES})
 
 add_executable(trossen_rslidar_main
-               src/trossen_rslidar_main.cpp
+  src/trossen_rslidar_main.cpp
 )
 
 ament_target_dependencies(trossen_rslidar_main ${DEPENDENCIES})
@@ -139,24 +139,24 @@ install(
 )
 
 install(
-    TARGETS trossen_rslidar_main
-    RUNTIME DESTINATION lib/${PROJECT_NAME}
+  TARGETS trossen_rslidar_main
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
 install(
-    DIRECTORY
-        include/
-    DESTINATION
-        include/
+  DIRECTORY
+    include/
+  DESTINATION
+    include/
 )
 
 install(
-    DIRECTORY
-        config
-        launch
-        rviz
-    DESTINATION
-        share/${PROJECT_NAME}
+  DIRECTORY
+    config
+    launch
+    rviz
+  DESTINATION
+    share/${PROJECT_NAME}
 )
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,9 +106,16 @@ add_library(trossen_rslidar_node SHARED
     src/rslidar_helper.cpp
 )
 
+add_library(trossen_rslidar_node_managed SHARED
+  src/trossen_rslidar_node_managed.cpp
+  src/rslidar_helper.cpp
+)
+
 rclcpp_components_register_nodes(trossen_rslidar_node "robosense::lidar::PointCloudLFNode")
+rclcpp_components_register_nodes(trossen_rslidar_node_managed "robosense::lidar::PointCloudLFNodeManaged")
 
 ament_target_dependencies(trossen_rslidar_node ${DEPENDENCIES})
+ament_target_dependencies(trossen_rslidar_node_managed ${DEPENDENCIES})
 
 add_executable(trossen_rslidar_main
                src/trossen_rslidar_main.cpp
@@ -117,15 +124,18 @@ add_executable(trossen_rslidar_main
 ament_target_dependencies(trossen_rslidar_main ${DEPENDENCIES})
 
 target_link_libraries(trossen_rslidar_main
-                      trossen_rslidar_node
-                      ${YAML_CPP_LIBRARIES}
-                      ${rs_driver_LIBRARIES})
+  trossen_rslidar_node
+  ${YAML_CPP_LIBRARIES}
+  ${rs_driver_LIBRARIES}
+)
 
 install(
-    TARGETS trossen_rslidar_node
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin
+  TARGETS
+    trossen_rslidar_node
+    trossen_rslidar_node_managed
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 install(

--- a/include/trossen_rslidar_node_managed.hpp
+++ b/include/trossen_rslidar_node_managed.hpp
@@ -54,7 +54,9 @@ namespace robosense
 namespace lidar
 {
 
-class PointCloudLFNode : public rclcpp::Node
+using CallbackReturn = nav2_util::CallbackReturn;
+
+class PointCloudLFNode : public nav2_util::LifecycleNode
 {
     private:
     // ROS topic for publishing point cloud
@@ -100,6 +102,40 @@ class PointCloudLFNode : public rclcpp::Node
 
     // Desctructor for Lifecycle Node class
     ~PointCloudLFNode();
+
+    /**
+     * @brief Configure
+     * @return SUCCESS or FAILURE
+     */
+    CallbackReturn on_configure(const rclcpp_lifecycle::State & state) override;
+
+    /**
+     * @brief Activate
+     * @param state Reference to LifeCycle node state
+     * @return SUCCESS or FAILURE
+     */
+    CallbackReturn on_activate(const rclcpp_lifecycle::State & state) override;
+
+    /**
+     * @brief Deactivate
+     * @param state Reference to LifeCycle node state
+     * @return SUCCESS or FAILURE
+     */
+    CallbackReturn on_deactivate(const rclcpp_lifecycle::State & state) override;
+
+    /**
+     * @brief Cleanup
+     * @param state Reference to LifeCycle node state
+     * @return SUCCESS or FAILURE
+     */
+    CallbackReturn on_cleanup(const rclcpp_lifecycle::State & state) override;
+
+    /**
+     * @brief Shut down
+     * @param state Reference to LifeCycle node state
+     * @return SUCCESS or FAILURE
+     */
+    CallbackReturn on_shutdown(const rclcpp_lifecycle::State & state) override;
 
     /**
      * @brief Function to publish PointCloud2 message

--- a/include/trossen_rslidar_node_managed.hpp
+++ b/include/trossen_rslidar_node_managed.hpp
@@ -56,7 +56,7 @@ namespace lidar
 
 using CallbackReturn = nav2_util::CallbackReturn;
 
-class PointCloudLFNode : public nav2_util::LifecycleNode
+class PointCloudLFNodeManaged : public nav2_util::LifecycleNode
 {
     private:
     // ROS topic for publishing point cloud
@@ -98,10 +98,10 @@ class PointCloudLFNode : public nav2_util::LifecycleNode
 
     public:
     // Constructor for LifeCycle Node class
-    explicit PointCloudLFNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+    explicit PointCloudLFNodeManaged(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
     // Desctructor for Lifecycle Node class
-    ~PointCloudLFNode();
+    ~PointCloudLFNodeManaged();
 
     /**
      * @brief Configure

--- a/src/trossen_rslidar_node.cpp
+++ b/src/trossen_rslidar_node.cpp
@@ -44,52 +44,51 @@ namespace lidar
 PointCloudLFNode::PointCloudLFNode(const rclcpp::NodeOptions & options)
 : rclcpp::Node("trossen_rslidar", "", options)
 {
-    declare_parameter<std::string>("ros_frame_id", "rslidar");
-    declare_parameter<std::string>("ros_send_point_cloud_topic", "points");
-    declare_parameter<bool>("ros_send_by_rows", false);
-    declare_parameter<bool>("show_driver_config", false);
+  declare_parameter<std::string>("ros_frame_id", "rslidar");
+  declare_parameter<std::string>("ros_send_point_cloud_topic", "points");
+  declare_parameter<bool>("ros_send_by_rows", false);
+  declare_parameter<bool>("show_driver_config", false);
 
-    // input related
-    declare_parameter<uint16_t>("msop_port", 6699);
-    declare_parameter<uint16_t>("difop_port", 7788);
-    declare_parameter<std::string>("host_address", "0.0.0.0");
-    declare_parameter<std::string>("group_address", "0.0.0.0");
-    declare_parameter<bool>("use_vlan", false);
-    declare_parameter<std::string>("pcap_path", "");
-    declare_parameter<float>("pcap_rate", 1.0);
-    declare_parameter<bool>("pcap_repeat", true);
-    declare_parameter<uint16_t>("user_layer_bytes", 0);
-    declare_parameter<uint16_t>("tail_layer_bytes", 0);
+  // input related
+  declare_parameter<uint16_t>("msop_port", 6699);
+  declare_parameter<uint16_t>("difop_port", 7788);
+  declare_parameter<std::string>("host_address", "0.0.0.0");
+  declare_parameter<std::string>("group_address", "0.0.0.0");
+  declare_parameter<bool>("use_vlan", false);
+  declare_parameter<std::string>("pcap_path", "");
+  declare_parameter<float>("pcap_rate", 1.0);
+  declare_parameter<bool>("pcap_repeat", true);
+  declare_parameter<uint16_t>("user_layer_bytes", 0);
+  declare_parameter<uint16_t>("tail_layer_bytes", 0);
 
-    declare_parameter<std::string>("lidar_type", "RSHELIOS_16P");
+  declare_parameter<std::string>("lidar_type", "RSHELIOS_16P");
 
-    // decoder
-    declare_parameter<bool>("wait_for_difop", true);
-    declare_parameter<bool>("use_lidar_clock", false);
-    declare_parameter<float>("min_distance", 0.2);
-    declare_parameter<float>("max_distance", 200.0);
-    declare_parameter<float>("start_angle", 0.0);
-    declare_parameter<float>("end_angle", 360.0);
-    declare_parameter<bool>("dense_points", false);
-    declare_parameter<bool>("ts_first_point", false);
+  // decoder
+  declare_parameter<bool>("wait_for_difop", true);
+  declare_parameter<bool>("use_lidar_clock", false);
+  declare_parameter<float>("min_distance", 0.2);
+  declare_parameter<float>("max_distance", 200.0);
+  declare_parameter<float>("start_angle", 0.0);
+  declare_parameter<float>("end_angle", 360.0);
+  declare_parameter<bool>("dense_points", false);
+  declare_parameter<bool>("ts_first_point", false);
 
-    // mechanical decoder
-    declare_parameter<bool>("config_from_file", false);
-    declare_parameter<std::string>("angle_path", "");
+  // mechanical decoder
+  declare_parameter<bool>("config_from_file", false);
+  declare_parameter<std::string>("angle_path", "");
 
-    declare_parameter<uint16_t>("split_frame_mode", 1);
+  declare_parameter<uint16_t>("split_frame_mode", 1);
 
-    declare_parameter<float>("split_angle", 0.0);
-    declare_parameter<uint16_t>("num_blks_split", 0);
+  declare_parameter<float>("split_angle", 0.0);
+  declare_parameter<uint16_t>("num_blks_split", 0);
 
-    // transform
-    declare_parameter<float>("x", 0.0);
-    declare_parameter<float>("y", 0.0);
-    declare_parameter<float>("z", 0.0);
-    declare_parameter<float>("roll", 0.0);
-    declare_parameter<float>("pitch", 0.0);
-    declare_parameter<float>("yaw", 0.0);
-
+  // transform
+  declare_parameter<float>("x", 0.0);
+  declare_parameter<float>("y", 0.0);
+  declare_parameter<float>("z", 0.0);
+  declare_parameter<float>("roll", 0.0);
+  declare_parameter<float>("pitch", 0.0);
+  declare_parameter<float>("yaw", 0.0);
 
   get_parameter<std::string>("ros_frame_id", this->frame_id_);
   driver_parameters_.frame_id = this->frame_id_;

--- a/src/trossen_rslidar_node.cpp
+++ b/src/trossen_rslidar_node.cpp
@@ -157,11 +157,9 @@ PointCloudLFNode::PointCloudLFNode(const rclcpp::NodeOptions & options)
 
   if (!driver_ptr_->init(driver_parameters_))
   {
-    RS_ERROR << "Driver Initialize Error...." << RS_REND;
-    exit(-1);
+    RCLCPP_FATAL(get_logger(), "Failed to bring up RSLIDAR SDK Node: Driver Initialize Error");
+    exit(EXIT_FAILURE);
   }
-
-  RCLCPP_DEBUG(this->get_logger(), "Activating...");
 
   driver_ptr_->start();
 

--- a/src/trossen_rslidar_node.cpp
+++ b/src/trossen_rslidar_node.cpp
@@ -175,6 +175,14 @@ PointCloudLFNode::PointCloudLFNode(const rclcpp::NodeOptions & options)
 
 PointCloudLFNode::~PointCloudLFNode()
 {
+  driver_ptr_->stop();
+  free_point_cloud_queue_.clear();
+  point_cloud_queue_.clear();
+
+  to_exit_process_ = true;
+  point_cloud_process_thread_.join();
+  driver_ptr_.reset();
+  pub_pointcloud_.reset();
 }
 
 void PointCloudLFNode::sendPointCloud(const LidarPointCloudMsg& msg)

--- a/src/trossen_rslidar_node_managed.cpp
+++ b/src/trossen_rslidar_node_managed.cpp
@@ -34,68 +34,68 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************************************************************/
 
 
-#include <trossen_rslidar_node.hpp>
+#include <trossen_rslidar_node_managed.hpp>
 
 namespace robosense
 {
 namespace lidar
 {
 
-PointCloudLFNode::PointCloudLFNode(const rclcpp::NodeOptions & options)
+PointCloudLFNodeManaged::PointCloudLFNodeManaged(const rclcpp::NodeOptions & options)
 : nav2_util::LifecycleNode("trossen_rslidar", "", options)
 {
-    declare_parameter<std::string>("ros_frame_id", "rslidar");
-    declare_parameter<std::string>("ros_send_point_cloud_topic", "points");
-    declare_parameter<bool>("ros_send_by_rows", false);
-    declare_parameter<bool>("show_driver_config", false);
+  declare_parameter<std::string>("ros_frame_id", "rslidar");
+  declare_parameter<std::string>("ros_send_point_cloud_topic", "points");
+  declare_parameter<bool>("ros_send_by_rows", false);
+  declare_parameter<bool>("show_driver_config", false);
 
-    // input related
-    declare_parameter<uint16_t>("msop_port", 6699);
-    declare_parameter<uint16_t>("difop_port", 7788);
-    declare_parameter<std::string>("host_address", "0.0.0.0");
-    declare_parameter<std::string>("group_address", "0.0.0.0");
-    declare_parameter<bool>("use_vlan", false);
-    declare_parameter<std::string>("pcap_path", "");
-    declare_parameter<float>("pcap_rate", 1.0);
-    declare_parameter<bool>("pcap_repeat", true);
-    declare_parameter<uint16_t>("user_layer_bytes", 0);
-    declare_parameter<uint16_t>("tail_layer_bytes", 0);
+  // input related
+  declare_parameter<uint16_t>("msop_port", 6699);
+  declare_parameter<uint16_t>("difop_port", 7788);
+  declare_parameter<std::string>("host_address", "0.0.0.0");
+  declare_parameter<std::string>("group_address", "0.0.0.0");
+  declare_parameter<bool>("use_vlan", false);
+  declare_parameter<std::string>("pcap_path", "");
+  declare_parameter<float>("pcap_rate", 1.0);
+  declare_parameter<bool>("pcap_repeat", true);
+  declare_parameter<uint16_t>("user_layer_bytes", 0);
+  declare_parameter<uint16_t>("tail_layer_bytes", 0);
 
-    declare_parameter<std::string>("lidar_type", "RSHELIOS_16P");
+  declare_parameter<std::string>("lidar_type", "RSHELIOS_16P");
 
-    // decoder
-    declare_parameter<bool>("wait_for_difop", true);
-    declare_parameter<bool>("use_lidar_clock", false);
-    declare_parameter<float>("min_distance", 0.2);
-    declare_parameter<float>("max_distance", 200.0);
-    declare_parameter<float>("start_angle", 0.0);
-    declare_parameter<float>("end_angle", 360.0);
-    declare_parameter<bool>("dense_points", false);
-    declare_parameter<bool>("ts_first_point", false);
+  // decoder
+  declare_parameter<bool>("wait_for_difop", true);
+  declare_parameter<bool>("use_lidar_clock", false);
+  declare_parameter<float>("min_distance", 0.2);
+  declare_parameter<float>("max_distance", 200.0);
+  declare_parameter<float>("start_angle", 0.0);
+  declare_parameter<float>("end_angle", 360.0);
+  declare_parameter<bool>("dense_points", false);
+  declare_parameter<bool>("ts_first_point", false);
 
-    // mechanical decoder
-    declare_parameter<bool>("config_from_file", false);
-    declare_parameter<std::string>("angle_path", "");
+  // mechanical decoder
+  declare_parameter<bool>("config_from_file", false);
+  declare_parameter<std::string>("angle_path", "");
 
-    declare_parameter<uint16_t>("split_frame_mode", 1);
+  declare_parameter<uint16_t>("split_frame_mode", 1);
 
-    declare_parameter<float>("split_angle", 0.0);
-    declare_parameter<uint16_t>("num_blks_split", 0);
+  declare_parameter<float>("split_angle", 0.0);
+  declare_parameter<uint16_t>("num_blks_split", 0);
 
-    // transform
-    declare_parameter<float>("x", 0.0);
-    declare_parameter<float>("y", 0.0);
-    declare_parameter<float>("z", 0.0);
-    declare_parameter<float>("roll", 0.0);
-    declare_parameter<float>("pitch", 0.0);
-    declare_parameter<float>("yaw", 0.0);
+  // transform
+  declare_parameter<float>("x", 0.0);
+  declare_parameter<float>("y", 0.0);
+  declare_parameter<float>("z", 0.0);
+  declare_parameter<float>("roll", 0.0);
+  declare_parameter<float>("pitch", 0.0);
+  declare_parameter<float>("yaw", 0.0);
 }
 
-PointCloudLFNode::~PointCloudLFNode()
+PointCloudLFNodeManaged::~PointCloudLFNodeManaged()
 {
 }
 
-CallbackReturn PointCloudLFNode::on_configure(const rclcpp_lifecycle::State & /* state */)
+CallbackReturn PointCloudLFNodeManaged::on_configure(const rclcpp_lifecycle::State & /* state */)
 {
   RCLCPP_DEBUG(get_logger(), "Configuring...");
 
@@ -159,10 +159,10 @@ CallbackReturn PointCloudLFNode::on_configure(const rclcpp_lifecycle::State & /*
   }
 
   driver_ptr_.reset(new lidar::LidarDriver<LidarPointCloudMsg>());
-  driver_ptr_->regPointCloudCallback(std::bind(&PointCloudLFNode::getPointCloud, this),
-      std::bind(&PointCloudLFNode::putPointCloud, this, std::placeholders::_1));
+  driver_ptr_->regPointCloudCallback(std::bind(&PointCloudLFNodeManaged::getPointCloud, this),
+      std::bind(&PointCloudLFNodeManaged::putPointCloud, this, std::placeholders::_1));
   driver_ptr_->regExceptionCallback(
-      std::bind(&PointCloudLFNode::putException, this, std::placeholders::_1));
+      std::bind(&PointCloudLFNodeManaged::putException, this, std::placeholders::_1));
 
   if (!driver_ptr_->init(driver_parameters_))
   {
@@ -174,14 +174,14 @@ CallbackReturn PointCloudLFNode::on_configure(const rclcpp_lifecycle::State & /*
   return CallbackReturn::SUCCESS;
 }
 
-CallbackReturn PointCloudLFNode::on_activate(const rclcpp_lifecycle::State & /* state */)
+CallbackReturn PointCloudLFNodeManaged::on_activate(const rclcpp_lifecycle::State & /* state */)
 {
   RCLCPP_DEBUG(this->get_logger(), "Activating...");
 
   driver_ptr_->start();
 
   to_exit_process_ = false;
-  point_cloud_process_thread_ = std::thread(std::bind(&PointCloudLFNode::processPointCloud, this));
+  point_cloud_process_thread_ = std::thread(std::bind(&PointCloudLFNodeManaged::processPointCloud, this));
 
   pub_pointcloud_ = create_publisher<sensor_msgs::msg::PointCloud2>(
     this->point_cloud_topic_,
@@ -193,12 +193,12 @@ CallbackReturn PointCloudLFNode::on_activate(const rclcpp_lifecycle::State & /* 
   return CallbackReturn::SUCCESS;
 }
 
-void PointCloudLFNode::sendPointCloud(const LidarPointCloudMsg& msg)
+void PointCloudLFNodeManaged::sendPointCloud(const LidarPointCloudMsg& msg)
 {
   pub_pointcloud_->publish(robosense::lidar::toRosMsg(msg, frame_id_, send_by_rows_));
 }
 
-std::shared_ptr<LidarPointCloudMsg> PointCloudLFNode::getPointCloud(void)
+std::shared_ptr<LidarPointCloudMsg> PointCloudLFNodeManaged::getPointCloud(void)
 {
   std::shared_ptr<LidarPointCloudMsg> point_cloud = free_point_cloud_queue_.pop();
 
@@ -210,12 +210,12 @@ std::shared_ptr<LidarPointCloudMsg> PointCloudLFNode::getPointCloud(void)
   return std::make_shared<LidarPointCloudMsg>();
 }
 
-void PointCloudLFNode::putPointCloud(std::shared_ptr<LidarPointCloudMsg> msg)
+void PointCloudLFNodeManaged::putPointCloud(std::shared_ptr<LidarPointCloudMsg> msg)
 {
   point_cloud_queue_.push(msg);
 }
 
-void PointCloudLFNode::processPointCloud()
+void PointCloudLFNodeManaged::processPointCloud()
 {
   while (!to_exit_process_ && rclcpp::ok())
   {
@@ -231,7 +231,7 @@ void PointCloudLFNode::processPointCloud()
   }
 }
 
-void PointCloudLFNode::putException(const lidar::Error& msg)
+void PointCloudLFNodeManaged::putException(const lidar::Error& msg)
 {
   switch (msg.error_code_type)
   {
@@ -247,7 +247,7 @@ void PointCloudLFNode::putException(const lidar::Error& msg)
   }
 }
 
-CallbackReturn PointCloudLFNode::on_deactivate(const rclcpp_lifecycle::State & /* state */)
+CallbackReturn PointCloudLFNodeManaged::on_deactivate(const rclcpp_lifecycle::State & /* state */)
 {
   RCLCPP_DEBUG(get_logger(), "Deactivating...");
 
@@ -264,7 +264,7 @@ CallbackReturn PointCloudLFNode::on_deactivate(const rclcpp_lifecycle::State & /
   return CallbackReturn::SUCCESS;
 }
 
-CallbackReturn PointCloudLFNode::on_cleanup(const rclcpp_lifecycle::State & /* state */)
+CallbackReturn PointCloudLFNodeManaged::on_cleanup(const rclcpp_lifecycle::State & /* state */)
 {
   RCLCPP_DEBUG(get_logger(), "Cleaning up...");
   driver_ptr_.reset();
@@ -274,7 +274,7 @@ CallbackReturn PointCloudLFNode::on_cleanup(const rclcpp_lifecycle::State & /* s
   return CallbackReturn::SUCCESS;
 }
 
-CallbackReturn PointCloudLFNode::on_shutdown(const rclcpp_lifecycle::State & /* state */)
+CallbackReturn PointCloudLFNodeManaged::on_shutdown(const rclcpp_lifecycle::State & /* state */)
 {
   RCLCPP_DEBUG(get_logger(), "Shutting down...");
   RCLCPP_INFO(get_logger(), "Shut down complete.");
@@ -285,4 +285,4 @@ CallbackReturn PointCloudLFNode::on_shutdown(const rclcpp_lifecycle::State & /* 
 }  // namespace robosense
 
 #include "rclcpp_components/register_node_macro.hpp"
-RCLCPP_COMPONENTS_REGISTER_NODE(robosense::lidar::PointCloudLFNode)
+RCLCPP_COMPONENTS_REGISTER_NODE(robosense::lidar::PointCloudLFNodeManaged)

--- a/src/trossen_rslidar_node_managed.cpp
+++ b/src/trossen_rslidar_node_managed.cpp
@@ -166,8 +166,8 @@ CallbackReturn PointCloudLFNodeManaged::on_configure(const rclcpp_lifecycle::Sta
 
   if (!driver_ptr_->init(driver_parameters_))
   {
-    RS_ERROR << "Driver Initialize Error...." << RS_REND;
-    exit(-1);
+    RCLCPP_FATAL(get_logger(), "Failed to bring up RSLIDAR SDK Node: Driver Initialize Error");
+    exit(EXIT_FAILURE);
   }
 
   RCLCPP_INFO(get_logger(), "Configuration complete.");


### PR DESCRIPTION
This PR splits the RSLidar node into managed and not-managed variants. All interfaces are the same. The default node, `PointCloudLFNode`, will become not managed.

This temporarily resolves bringup issues where the RSLidar node would consistently crash on activation.

More investigation will be needed to narrow down what the actual root cause of it crashing.