### PR TITLE
Add frequency diagnostic for pointcloud publication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,8 @@ endif()
 #========================
 
 find_package(ament_cmake REQUIRED)
+find_package(diagnostic_msgs REQUIRED)
+find_package(diagnostic_updater REQUIRED)
 find_package(nav2_util REQUIRED)
 find_package(rclcpp QUIET)
 find_package(rclcpp_components REQUIRED)
@@ -93,6 +95,8 @@ find_package(rs_driver REQUIRED)
 include_directories(${rs_driver_INCLUDE_DIRS})
 
 set(DEPENDENCIES
+  diagnostic_msgs
+  diagnostic_updater
   nav2_util
   rclcpp
   rclcpp_components

--- a/config/trossen_rslidar_node.yaml
+++ b/config/trossen_rslidar_node.yaml
@@ -53,3 +53,18 @@ trossen_rslidar_node:
 
     # true to use the lidar clock as the message timestamp, false to use the system clock (default: false)
     use_lidar_clock: false
+
+    # The name of the lidar used in diagnostics (default: "lidar")
+    lidar_diagnostic_name: "lidar"
+
+    # Minimum frequency (Hz) for the pointcloud publisher - used in diagnostics (default: 10.0)
+    minimum_frequency: 10.0
+
+    # Maximum frequency (Hz) for the pointcloud publisher - used in diagnostics (default: 10.0)
+    maximum_frequency: 10.0
+
+    # Tolerance with which bounds must be satisfied (default: 0.1)
+    frequency_tolerance: 0.1
+
+    # Number of events to consider in the statistics (default: 5)
+    frequency_window: 10

--- a/include/trossen_rslidar_node.hpp
+++ b/include/trossen_rslidar_node.hpp
@@ -41,13 +41,16 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sstream>
 #include <string>
 
-#include <nav2_util/lifecycle_node.hpp>
-#include <rclcpp/rclcpp.hpp>
-#include <rs_driver/api/lidar_driver.hpp>
-#include <rs_driver/utility/sync_queue.hpp>
-#include <rslidar_helper.hpp>
-#include <sensor_msgs/point_cloud2_iterator.hpp>
-#include <utility/yaml_reader.hpp>
+#include "diagnostic_msgs/msg/diagnostic_status.hpp"
+#include "diagnostic_updater/diagnostic_updater.hpp"
+#include "diagnostic_updater/publisher.hpp"
+#include "diagnostic_updater/update_functions.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rs_driver/api/lidar_driver.hpp"
+#include "rs_driver/utility/sync_queue.hpp"
+#include "rslidar_helper.hpp"
+#include "sensor_msgs/point_cloud2_iterator.hpp"
+#include "utility/yaml_reader.hpp"
 
 namespace robosense
 {
@@ -93,6 +96,12 @@ class PointCloudLFNode : public rclcpp::Node
 
     // Flag to terminate the Process PointCloud thread
     bool to_exit_process_;
+
+    // Diagnostic updater - used to report status of this node and related hardware
+    diagnostic_updater::Updater diagnostic_updater_;
+
+    // Diagnostic for the PointCloud2 publisher's frequency
+    std::shared_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> pub_pointcloud_diagnostic_;
 
     public:
     // Constructor for LifeCycle Node class

--- a/include/trossen_rslidar_node.hpp
+++ b/include/trossen_rslidar_node.hpp
@@ -100,6 +100,18 @@ class PointCloudLFNode : public rclcpp::Node
     // Diagnostic updater - used to report status of this node and related hardware
     diagnostic_updater::Updater diagnostic_updater_;
 
+    // Minimum frequency for the pointcloud publisher - used in diagnostics
+    double minimum_frequency_;
+
+    // Maximum frequency for the pointcloud publisher - used in diagnostics
+    double maximum_frequency_;
+
+    // Tolerance with which bounds must be satisfied
+    double frequency_tolerance_;
+
+    // Number of events to consider in the statistics
+    int frequency_window_;
+
     // Diagnostic for the PointCloud2 publisher's frequency
     std::shared_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> pub_pointcloud_diagnostic_;
 

--- a/package.xml
+++ b/package.xml
@@ -7,6 +7,8 @@
   <license>BSD</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>diagnostic_msgs</depend>
+  <depend>diagnostic_updater</depend>
   <depend>launch_ros</depend>
   <depend>launch</depend>
   <depend>nav2_util</depend>

--- a/src/trossen_rslidar_node.cpp
+++ b/src/trossen_rslidar_node.cpp
@@ -42,7 +42,8 @@ namespace lidar
 {
 
 PointCloudLFNode::PointCloudLFNode(const rclcpp::NodeOptions & options)
-: rclcpp::Node("trossen_rslidar", "", options)
+: rclcpp::Node("trossen_rslidar", "", options),
+  diagnostic_updater_(this)
 {
   declare_parameter<std::string>("ros_frame_id", "rslidar");
   declare_parameter<std::string>("ros_send_point_cloud_topic", "points");
@@ -89,6 +90,11 @@ PointCloudLFNode::PointCloudLFNode(const rclcpp::NodeOptions & options)
   declare_parameter<float>("roll", 0.0);
   declare_parameter<float>("pitch", 0.0);
   declare_parameter<float>("yaw", 0.0);
+
+  // diagnostic parameters
+  declare_parameter<std::string>("lidar_diagnostic_name", "lidar");
+  declare_parameter<double>("minimum_frequency", 8.0);
+  declare_parameter<double>("minimum_frequency", 12.0);
 
   get_parameter<std::string>("ros_frame_id", this->frame_id_);
   driver_parameters_.frame_id = this->frame_id_;
@@ -142,6 +148,23 @@ PointCloudLFNode::PointCloudLFNode(const rclcpp::NodeOptions & options)
   get_parameter<float>("pitch", driver_parameters_.decoder_param.transform_param.pitch);
   get_parameter<float>("yaw", driver_parameters_.decoder_param.transform_param.yaw);
 
+  // diagnostic parameters
+  std::string lidar_diagnostic_name;
+  get_parameter<std::string>("lidar_diagnostic_name", lidar_diagnostic_name);
+  double minimum_frequency, maximum_frequency;
+  get_parameter<double>("minimum_frequency", minimum_frequency);
+  get_parameter<double>("maximum_frequency", maximum_frequency);
+
+  diagnostic_updater_.setHardwareID(lidar_diagnostic_name);
+  pub_pointcloud_diagnostic_ = std::make_shared<diagnostic_updater::HeaderlessTopicDiagnostic>(
+    point_cloud_topic_,
+    diagnostic_updater_,
+    diagnostic_updater::FrequencyStatusParam(
+      &minimum_frequency,
+      &maximum_frequency,
+      /*tolerance=*/0.1,
+      /*window_size=*/10));
+
   driver_parameters_.input_type = InputType::ONLINE_LIDAR;
 
   if (this->show_driver_config_)
@@ -183,11 +206,13 @@ PointCloudLFNode::~PointCloudLFNode()
   point_cloud_process_thread_.join();
   driver_ptr_.reset();
   pub_pointcloud_.reset();
+  pub_pointcloud_diagnostic_.reset();
 }
 
 void PointCloudLFNode::sendPointCloud(const LidarPointCloudMsg& msg)
 {
   pub_pointcloud_->publish(robosense::lidar::toRosMsg(msg, frame_id_, send_by_rows_));
+  pub_pointcloud_diagnostic_->tick();
 }
 
 std::shared_ptr<LidarPointCloudMsg> PointCloudLFNode::getPointCloud(void)


### PR DESCRIPTION
This PR adds a frequency diagnostic for the lidar's pointcloud publisher along with configurable upper and lower bounds.